### PR TITLE
Add 'deploy project' and optional JSON support for 'project'

### DIFF
--- a/Functions/DeployProject/Get-BambooDeployProject.ps1
+++ b/Functions/DeployProject/Get-BambooDeployProject.ps1
@@ -18,12 +18,14 @@ function Get-BambooDeployProject {
         [string]$DeploymentProjectId
     )
 
+    $ContentType = 'application/json'
+    Write-Warning "Get-BambooDeployProject: The Bamboo API for 'Deploy Projects' only supports JSON response format. Using content-type: $ContentType"
+
     $resource = 'deploy/project/all'
     if ($DeploymentProjectId) {
         $resource = "deploy/project/$DeploymentProjectId"
     }
 
-    Invoke-BambooRestMethod -Resource $resource |
-    Expand-BambooResource -ResourceName 'deploymentproject' |
+    Invoke-BambooRestMethod -Resource $resource -ContentType $ContentType |
     Add_ObjectType -TypeName 'PsBamboo.DeployProject'
 }

--- a/Functions/DeployProject/Get-BambooDeployProject.ps1
+++ b/Functions/DeployProject/Get-BambooDeployProject.ps1
@@ -18,7 +18,7 @@ function Get-BambooDeployProject {
         [string]$DeploymentProjectId
     )
 
-    $resource = 'deploy/project'
+    $resource = 'deploy/project/all'
     if ($DeploymentProjectId) {
         $resource = "deploy/project/$DeploymentProjectId"
     }

--- a/Functions/DeployProject/Get-BambooDeployProject.ps1
+++ b/Functions/DeployProject/Get-BambooDeployProject.ps1
@@ -1,0 +1,29 @@
+<#
+.SYNOPSIS
+    Gets all deploy projects or describes a single Bamboo Deploy Project.
+.DESCRIPTION
+    If -DeploymentProjectId is specified it describes only that deploy project.
+.PARAMETER DeploymentProjectId
+    Optional - Key for the Bamboo Deploy Project to be described
+.EXAMPLE
+    Get-BambooDeployProject
+.EXAMPLE
+    Get-BambooDeployProject -DeploymentProjectId 'PRJ'
+#>
+function Get-BambooDeployProject {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidatePattern('\w+')]
+        [string]$DeploymentProjectId
+    )
+
+    $resource = 'deploy/project'
+    if ($DeploymentProjectId) {
+        $resource = "deploy/project/$DeploymentProjectId"
+    }
+
+    Invoke-BambooRestMethod -Resource $resource |
+    Expand-BambooResource -ResourceName 'project' |
+    Add_ObjectType -TypeName 'PsBamboo.DeployProject'
+}

--- a/Functions/DeployProject/Get-BambooDeployProject.ps1
+++ b/Functions/DeployProject/Get-BambooDeployProject.ps1
@@ -24,6 +24,6 @@ function Get-BambooDeployProject {
     }
 
     Invoke-BambooRestMethod -Resource $resource |
-    Expand-BambooResource -ResourceName 'project' |
+    Expand-BambooResource -ResourceName 'deploymentproject' |
     Add_ObjectType -TypeName 'PsBamboo.DeployProject'
 }

--- a/Functions/DeployProject/PsBamboo.Project.format.ps1xml
+++ b/Functions/DeployProject/PsBamboo.Project.format.ps1xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+  <ViewDefinitions>
+     <View>
+      <Name>PsBamboo.DeployProject</Name>
+      <ViewSelectedBy>
+        <TypeName>PsBamboo.DeployProject</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>key</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>name</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/Functions/DeployProject/PsBamboo.Project.format.ps1xml
+++ b/Functions/DeployProject/PsBamboo.Project.format.ps1xml
@@ -11,7 +11,7 @@
           <TableRowEntry>
             <TableColumnItems>
               <TableColumnItem>
-                <PropertyName>key</PropertyName>
+                <PropertyName>id</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>name</PropertyName>

--- a/Functions/DeployProject/PsBamboo.Project.format.ps1xml
+++ b/Functions/DeployProject/PsBamboo.Project.format.ps1xml
@@ -16,6 +16,9 @@
               <TableColumnItem>
                 <PropertyName>name</PropertyName>
               </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>description</PropertyName>
+              </TableColumnItem>              
             </TableColumnItems>
           </TableRowEntry>
         </TableRowEntries>

--- a/Functions/Invoke-BambooRestMethod.ps1
+++ b/Functions/Invoke-BambooRestMethod.ps1
@@ -52,7 +52,7 @@ function Invoke-BambooRestMethod {
         [string]$AuthenticationToken = $script:AuthenticationToken,
 
         [string]$Expand,
-        [string]$ContentType='application/xml',
+        [string]$ContentType='application/json',
         
         [psobject]$UriParams=@{},
         [psobject]$Headers=@{},

--- a/Functions/Invoke-BambooRestMethod.ps1
+++ b/Functions/Invoke-BambooRestMethod.ps1
@@ -52,7 +52,7 @@ function Invoke-BambooRestMethod {
         [string]$AuthenticationToken = $script:AuthenticationToken,
 
         [string]$Expand,
-        [string]$ContentType='application/json',
+        [string]$ContentType='application/xml',
         
         [psobject]$UriParams=@{},
         [psobject]$Headers=@{},

--- a/Functions/Invoke-BambooRestMethod.ps1
+++ b/Functions/Invoke-BambooRestMethod.ps1
@@ -73,6 +73,10 @@ function Invoke-BambooRestMethod {
         }
     }
 
+    if ($ContentType -eq 'application/json'){
+        $Uri = -Join ($Uri, '.json')
+    }
+
     if ($UriParams -and $UriParams.Keys) {
         $Params = ''
         foreach($key in $UriParams.Keys) {

--- a/Functions/Project/Get-BambooProject.ps1
+++ b/Functions/Project/Get-BambooProject.ps1
@@ -15,15 +15,27 @@ function Get-BambooProject {
     param(
         [Parameter()]
         [ValidatePattern('\w+')]
-        [string]$ProjectKey
+        [string]$ProjectKey,
+        [Parameter()]
+        [switch]$JsonResponse
     )
+
+    $ContentType = 'application/xml'
+    
+    if ($JsonResponse -eq $True){
+        $ContentType = 'application/json'
+    }
 
     $resource = 'project'
     if ($ProjectKey) {
         $resource = "project/$ProjectKey"
     }
 
-    Invoke-BambooRestMethod -Resource $resource |
-    Expand-BambooResource -ResourceName 'project' |
-    Add_ObjectType -TypeName 'PsBamboo.Project'
+    $response = Invoke-BambooRestMethod -Resource $resource -ContentType $ContentType 
+    
+    if (-not $JsonResponse){
+        $response = $response | Expand-BambooResource -ResourceName 'project'
+    }
+
+    $response | Add_ObjectType -TypeName 'PsBamboo.Project'
 }

--- a/PsBamboo.psd1
+++ b/PsBamboo.psd1
@@ -74,6 +74,7 @@ FunctionsToExport = @(
     'Expand-BambooResource'
     'Get-BambooArtifact'
     'Get-BambooCurrentUser'
+    'Get-BambooDeployProject'    
     'Get-BambooInfo'
     'Get-BambooPlan'
     'Get-BambooPlanBranch'

--- a/Tests/BambooModule/expected_commands.csv
+++ b/Tests/BambooModule/expected_commands.csv
@@ -10,6 +10,7 @@ Get-BambooArtifact
 Get-BambooBuild
 Get-BambooBuildLog
 Get-BambooCurrentUser
+Get-BambooDeployProject
 Get-BambooInfo
 Get-BambooPlan
 Get-BambooPlanBranch


### PR DESCRIPTION
This PR began as simply looking to extend PsBamboo to support retrieving 'Deploy Projects', it would however seem that the API is inconsistently implemented and the `deploy/project' endpoint only supports JSON responses https://docs.atlassian.com/bamboo/REST/5.5.0/#d2e85. Therefore this PR provides the following:

* Introduces the `Get-BambooDeployProject` function, following the existing patterns, this only allows use of JSON response objects so swerves passing the response through the `Expand-BambooResource` function
* As an example extends `Get-BambooProject` to include a `JsonResponse` switch to query Bamboo using the JSON MIME type instead of XML. XML is still however the default and requires no changes to how the functions are currently called.
* Some minor mods to `Invoke-BambooRestMethod` to support the above changes.

Note: I set up my own AppVeyor build and all is passing. 